### PR TITLE
makefile with explicit compile stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 
-default:
-	gcc -Wall -Werror -lncurses -lpthread chrono.c -o chrono
 
+all: default
+
+default: chrono
+
+chrono: chrono.o
+	gcc -Wall -Werror -lncurses -lpthread chrono.o -o chrono
+
+chrono.o: chrono.c


### PR DESCRIPTION
your makefile works fine... only difference is mine separates the compile stages. also, the action is missing on some of them because there's already (for example) an implicit rule that does foo.c -> foo.o, so I didn't need one to show make how to do that